### PR TITLE
version checker fix for EE 2.10.1

### DIFF
--- a/system/expressionengine/third_party/developer_info/libraries/developer_info_helper.php
+++ b/system/expressionengine/third_party/developer_info/libraries/developer_info_helper.php
@@ -43,7 +43,7 @@ class Developer_Info_helper
 		{
 			$line = $line . ': ' . $page;
 		}
-		if (APP_VER >= '2.6')
+		if (version_compare(APP_VER, '2.6.0', '>='))	
 		{
 			$this->EE->view->cp_page_title = $this->EE->lang->line($line);
 		} 


### PR DESCRIPTION
Hi Marc,
On installing EE 2.10.1 and your Developer Info add-on, I was getting an error Call to undefined method Cp::set_variable()
So I used this info to update the 2.6 version check & get it working again
http://expressionengine.stackexchange.com/questions/31439/member-group-tabs-throws-blank-screen-after-ee-upgrade-to-2-10
Thanks,
Janine.
